### PR TITLE
SHA 3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SHA3-CS"]
+	path = SHA3-CS
+	url = https://github.com/E-gy/SHA3-CS

--- a/Core/Epicoin Core.csproj
+++ b/Core/Epicoin Core.csproj
@@ -9,4 +9,8 @@
     <PackageReference Include="Newtonsoft.JSON" Version="12.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\SHA3-CS\SHA3-CS\SHA3-CS.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
SHA3 taken from own implementation at https://github.com/E-gy/SHA3-CS and imported as a Git Submodule.
[Will] Switch to dependency DLL once the repo is on nuget.