### PR TITLE
Standard Interthread Messages and Events

### DIFF
--- a/Core/EFOBE.cs
+++ b/Core/EFOBE.cs
@@ -92,11 +92,23 @@ namespace Epicoin.Core {
 
 		internal class ITM : ITCMessage {
 
-			internal class GetProblemsRegistry : ITM {
+			internal class GetProblemsRegistry : ITM { //From Solver
 
 				public readonly ImmutableDictionary<string, NPcProblemWrapper> problemsRegistry;
 
 				public GetProblemsRegistry(IDictionary<string, NPcProblemWrapper> reg) => problemsRegistry = reg is ImmutableDictionary<string, NPcProblemWrapper> ? reg as ImmutableDictionary<string, NPcProblemWrapper> : ImmutableDictionary.ToImmutableDictionary(reg);
+
+			}
+
+			internal class ProblemSolved : ITM { //From Solver
+
+			}
+
+			internal class EFOBERemoteBlockAdded : ITM { //From Network
+
+			}
+
+			internal class EFOBERemoteBlockRebase : ITM { //From Network
 
 			}
 

--- a/Core/EFOBE.cs
+++ b/Core/EFOBE.cs
@@ -126,6 +126,12 @@ namespace Epicoin.Core {
 			internal class EFOBERemoteBlockRebase : ITM { //From Network
 				public readonly string Hash;
 				public readonly string NewParent, NewHash;
+
+				public EFOBERemoteBlockRebase(string hash, string newParent, string newHash){
+					this.Hash = hash;
+					this.NewParent = newParent;
+					this.NewHash = newHash;
+				}
 			}
 
 		}

--- a/Core/EFOBE.cs
+++ b/Core/EFOBE.cs
@@ -135,10 +135,10 @@ namespace Epicoin.Core {
 			}
 
 			internal class EFOBEReqReply : ITM {
-				public readonly string cachedEFOBEFile;
+				public readonly FileInfo cachedEFOBE;
 
-				public EFOBEReqReply(string cache){
-					this.cachedEFOBEFile = cache;
+				public EFOBEReqReply(FileInfo cache){
+					this.cachedEFOBE = cache;
 				}
 			}
 

--- a/Core/EFOBE.cs
+++ b/Core/EFOBE.cs
@@ -101,15 +101,31 @@ namespace Epicoin.Core {
 			}
 
 			internal class ProblemSolved : ITM { //From Solver
+				public readonly string Problem, Parameters, Solution;
 
+				public ProblemSolved(string problem, string parms, string sol){
+					this.Problem = problem;
+					this.Parameters = parms;
+					this.Solution = sol;
+				}
 			}
 
 			internal class EFOBERemoteBlockAdded : ITM { //From Network
+				public readonly string Problem, Parameters, Solution;
+				public readonly string Parent, Hash;
 
+				public EFOBERemoteBlockAdded(string problem, string parms, string sol, string parent, string hash){
+					this.Problem = problem;
+					this.Parameters = parms;
+					this.Solution = sol;
+					this.Parent = parent;
+					this.Hash = hash;
+				}
 			}
 
 			internal class EFOBERemoteBlockRebase : ITM { //From Network
-
+				public readonly string Hash;
+				public readonly string NewParent, NewHash;
 			}
 
 		}

--- a/Core/EFOBE.cs
+++ b/Core/EFOBE.cs
@@ -153,6 +153,14 @@ namespace Epicoin.Core {
 				}
 			}
 
+			internal class EFOBESendRequest : ITM {
+				public readonly FileInfo cacheEFOBEHere;
+
+				public EFOBESendRequest(FileInfo cache){
+					this.cacheEFOBEHere = cache;
+				}
+			}
+
 		}
 
 	}

--- a/Core/EFOBE.cs
+++ b/Core/EFOBE.cs
@@ -12,7 +12,7 @@ namespace Epicoin.Core {
 	/// <summary>
 	/// The Epic Free and Open Blockchain of Epicness itself, in all its' structural glory.
 	/// </summary>
-	public class EFOBE {
+	public class EFOBE : EFOBEEvents {
 
 		private List<Block> blocks;
 
@@ -56,6 +56,17 @@ namespace Epicoin.Core {
 			public override string ToString() => $"[{problem} @ {hash}]";
 
 		}
+
+		//Events
+		public event Action<(string Problem, string Parameters, string Solution, string Parent, string Hash)> OnBlockAdded;
+		private void FireOnBlockAdded(string Problem, string Parameters, string Solution, string Parent, string Hash) => AsyncEventsManager.FireAsync(OnBlockAdded, (Problem, Parameters, Solution, Parent, Hash));
+		public event Action<(string Problem, string Parameters, string Solution, string Hash)> OnBlockImmortalized;
+		private void FireOnBlockImmortalized(string Problem, string Parameters, string Solution, string Hash) => AsyncEventsManager.FireAsync(OnBlockImmortalized, (Problem, Parameters, Solution, Hash));
+		public event Action<(string Problem, string Parameters, string Solution, string Hash)> OnLCAChanged;
+		private void FireOnLCAChanged(string Problem, string Parameters, string Solution, string Hash) => AsyncEventsManager.FireAsync(OnLCAChanged, (Problem, Parameters, Solution, Hash));
+		public event Action<(string Problem, string Parameters, string Solution, string OldParent, string OldHash, string NewParent, string NewHash)> OnBranchRebased;
+		private void FireOnBranchRebased(string Problem, string Parameters, string Solution, string OldParent, string OldHash, string NewParent, string NewHash) => AsyncEventsManager.FireAsync(OnBranchRebased, (Problem, Parameters, Solution, OldParent, OldHash, NewParent, NewHash));
+
 	}
 
 	/// <summary>

--- a/Core/EFOBE.cs
+++ b/Core/EFOBE.cs
@@ -134,6 +134,14 @@ namespace Epicoin.Core {
 				}
 			}
 
+			internal class EFOBEReqReply : ITM {
+				public readonly string cachedEFOBEFile;
+
+				public EFOBEReqReply(string cache){
+					this.cachedEFOBEFile = cache;
+				}
+			}
+
 		}
 
 	}

--- a/Core/EPI.cs
+++ b/Core/EPI.cs
@@ -42,6 +42,11 @@ namespace Epicoin.Core {
 	/// Asynchronous - all events are fired and processed asynchronously from all epicore and your threads, [thus] heavy computations can be potentially performed directly in the event handler.
 	/// </summary>
 	public interface EpicoreEvents {
+
+		event Action<ISolver> OnSolverInitialized;
+		event Action<IValidator> OnValidatorInitialized;
+		event Action<INet> OnNetworkingInitialized;
+
 		event Action<(string Problem, string Parameters)> OnStartedSolvingProblem;
 		event Action<(string Problem, string Parameters, string Solution)> OnProblemSolved;
 	}

--- a/Core/EPI.cs
+++ b/Core/EPI.cs
@@ -25,6 +25,11 @@ namespace Epicoin.Core {
 		void Start();
 
 		/// <summary>
+		/// Requests Epicoin to solve given problem - adds it to local queue (if solving is enabled) and tells everyone around as wel.
+		/// </summary>
+		void SolveAProblem(string problem, string parameters);
+
+		/// <summary>
 		/// Stops Epicore. Blocking - blocks until all Epicore components have stopped.
 		/// </summary>
 		void Stop();

--- a/Core/EPI.cs
+++ b/Core/EPI.cs
@@ -47,8 +47,20 @@ namespace Epicoin.Core {
 		event Action<IValidator> OnValidatorInitialized;
 		event Action<INet> OnNetworkingInitialized;
 
+		event Action<EFOBE> OnEFOBEAcquired;
+
 		event Action<(string Problem, string Parameters)> OnStartedSolvingProblem;
 		event Action<(string Problem, string Parameters, string Solution)> OnProblemSolved;
+	}
+
+	/// <summary>
+	/// Public events taking place in the EFOBE. Follow the same async execution as Epicore events
+	/// </summary>
+	public interface EFOBEEvents {
+		event Action<(string Problem, string Parameters, string Solution, string Parent, string Hash)> OnBlockAdded;
+		event Action<(string Problem, string Parameters, string Solution, string Hash)> OnBlockImmortalized;
+		event Action<(string Problem, string Parameters, string Solution, string Hash)> OnLCAChanged;
+		event Action<(string Problem, string Parameters, string Solution, string OldParent, string OldHash, string NewParent, string NewHash)> OnBranchRebased;
 	}
 
 	/// <summary>

--- a/Core/Epicore.cs
+++ b/Core/Epicore.cs
@@ -101,6 +101,9 @@ namespace Epicoin.Core {
 		public event Action<INet> OnNetworkingInitialized;
 		public void FireOnNetworkingInitialized(INet net) => FireAsync(OnNetworkingInitialized, net);
 
+		public event Action<EFOBE> OnEFOBEAcquired;
+		public void FireOneEFOBEAcquired(EFOBE efobe) => FireAsync(OnEFOBEAcquired, efobe);
+
 		public event Action<(string, string)> OnStartedSolvingProblem;
 		public void FireOnStartedSolvingProblem(string problem, string parms) => FireAsync(OnStartedSolvingProblem, (problem, parms));
 		public event Action<(string, string, string)> OnProblemSolved;

--- a/Core/Epicore.cs
+++ b/Core/Epicore.cs
@@ -94,6 +94,13 @@ namespace Epicoin.Core {
 		public static void FireAsync<T1,T2,T3,T4>(Action<T1,T2,T3,T4> eve, T1 param1, T2 param2, T3 param3, T4 param4) => RAINN(eve, () => eve(param1, param2, param3, param4));
 		public static void FireAsync<T1,T2,T3,T4,T5>(Action<T1,T2,T3,T4,T5> eve, T1 param1, T2 param2, T3 param3, T4 param4, T5 param5) => RAINN(eve, () => eve(param1, param2, param3, param4, param5));
 
+		public event Action<ISolver> OnSolverInitialized;
+		public void FireOnSolverInitialized(Solver solver) => FireAsync(OnSolverInitialized, solver);
+		public event Action<IValidator> OnValidatorInitialized;
+		public void FireOnValidatorInitialized(Validator validator) => FireAsync(OnValidatorInitialized, validator);
+		public event Action<INet> OnNetworkingInitialized;
+		public void FireOnNetworkingInitialized(INet net) => FireAsync(OnNetworkingInitialized, net);
+
 		public event Action<(string, string)> OnStartedSolvingProblem;
 		public void FireOnStartedSolvingProblem(string problem, string parms) => FireAsync(OnStartedSolvingProblem, (problem, parms));
 		public event Action<(string, string, string)> OnProblemSolved;

--- a/Core/Epicore.cs
+++ b/Core/Epicore.cs
@@ -68,6 +68,11 @@ namespace Epicoin.Core {
 			st.Start();
 		}
 
+		public void SolveAProblem(string problem, string parameters){
+			//sendITM2Net(new Epicoin.Core.Net.ITM.ProblemToSolve(problem, parameters));
+			sendITM2Solver(new Solver.ITM.ProblemToBeSolved(problem, parameters));
+		}
+
 		/// <summary>
 		/// Stops Epicore (and all related threads). Blocking - blocks until all Epicore components have stopped.
 		/// </summary>

--- a/Core/Epinet/NetITC.cs
+++ b/Core/Epinet/NetITC.cs
@@ -5,10 +5,26 @@ using Epicoin.Core;
 namespace Epicoin.Core.Net {
 	internal class ITM : ITCMessage {
 		internal class EFOBELocalBlockAdded : ITM { //From EFOBE/Validator
-			
+			public readonly string Problem, Parameters, Solution;
+			public readonly string Parent, Hash;
+
+			public EFOBELocalBlockAdded(string problem, string parms, string sol, string parent, string hash){
+				this.Problem = problem;
+				this.Parameters = parms;
+				this.Solution = sol;
+				this.Parent = parent;
+				this.Hash = hash;
+			}
 		}
 		internal class EFOBELocalBlockRebase : ITM { //From EFOBE/Validator
+			public readonly string Hash;
+			public readonly string NewParent, NewHash;
 
+			public EFOBELocalBlockRebase(string hash, string newParent, string newHash){
+				this.Hash = hash;
+				this.NewParent = newParent;
+				this.NewHash = newHash;
+			}
 		}
 	}
 }

--- a/Core/Epinet/NetITC.cs
+++ b/Core/Epinet/NetITC.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 
 using Epicoin.Core;
 
@@ -28,6 +29,13 @@ namespace Epicoin.Core.Net {
 		}
 		internal class EFOBERequest : ITM {
 
+		}
+		internal class EFOBESendRequestReply : ITM {
+			public readonly FileInfo cacheEFOBEHere;
+
+			public EFOBESendRequestReply(FileInfo cache){
+				this.cacheEFOBEHere = cache;
+			}
 		}
 	}
 }

--- a/Core/Epinet/NetITC.cs
+++ b/Core/Epinet/NetITC.cs
@@ -26,5 +26,8 @@ namespace Epicoin.Core.Net {
 				this.NewHash = newHash;
 			}
 		}
+		internal class EFOBERequest : ITM {
+
+		}
 	}
 }

--- a/Core/Epinet/NetITC.cs
+++ b/Core/Epinet/NetITC.cs
@@ -5,6 +5,14 @@ using Epicoin.Core;
 
 namespace Epicoin.Core.Net {
 	internal class ITM : ITCMessage {
+		internal class ProblemToSolve : ITM {
+			public readonly string Problem, Parameters;
+
+			public ProblemToSolve(string problem, string parms){
+				this.Problem = problem;
+				this.Parameters = parms;
+			}
+		}
 		internal class EFOBELocalBlockAdded : ITM { //From EFOBE/Validator
 			public readonly string Problem, Parameters, Solution;
 			public readonly string Parent, Hash;

--- a/Core/Epinet/NetITC.cs
+++ b/Core/Epinet/NetITC.cs
@@ -4,6 +4,11 @@ using Epicoin.Core;
 
 namespace Epicoin.Core.Net {
 	internal class ITM : ITCMessage {
+		internal class EFOBELocalBlockAdded : ITM { //From EFOBE/Validator
+			
+		}
+		internal class EFOBELocalBlockRebase : ITM { //From EFOBE/Validator
 
+		}
 	}
 }

--- a/Core/NPcP.cs
+++ b/Core/NPcP.cs
@@ -125,10 +125,20 @@ namespace Epicoin.Core {
 
 		internal class ITM : ITCMessage {
 			internal class ProblemToBeSolved : ITM { //From Network
+				public readonly string Problem, Parameters;
 
+				public ProblemToBeSolved(string problem, string parms){
+					this.Problem = problem;
+					this.Parameters = parms;
+				}
 			}
 			internal class CancelPendingProblem : ITM { //From Validator
+				public readonly string Problem, Parameters;
 
+				public CancelPendingProblem(string problem, string parms){
+					this.Problem = problem;
+					this.Parameters = parms;
+				}
 			}
 		}
 

--- a/Core/NPcP.cs
+++ b/Core/NPcP.cs
@@ -124,7 +124,12 @@ namespace Epicoin.Core {
 		 */
 
 		internal class ITM : ITCMessage {
+			internal class ProblemToBeSolved : ITM { //From Network
 
+			}
+			internal class CancelPendingProblem : ITM { //From Validator
+
+			}
 		}
 
 	}


### PR DESCRIPTION
Definitive base internal classes for ITC between modules, as per ITM diagram.
Should contain all cases where ITC is used (plus a few not-yet-implemented cases).
For network ITCs, a dedicated [temporary] class was created as to avoid potential future merge issues with a well-defined class in a not-yet-consolidated module.